### PR TITLE
Fix required package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,9 @@ setup(
         'groups_cache',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=[
+        'hashids',
+    ],
     license="MIT",
     zip_safe=False,
     keywords='django-groups-cache',


### PR DESCRIPTION
When installing the library with pip install it does not install `hashids`.

Ran tests: https://travis-ci.org/jrobichaud/django-groups-cache/builds/509045351